### PR TITLE
feature: Remove multiline directives to simplify them

### DIFF
--- a/src/main/java/com/virtuslab/using_directives/custom/Scanner.java
+++ b/src/main/java/com/virtuslab/using_directives/custom/Scanner.java
@@ -385,9 +385,6 @@ public class Scanner {
       case END:
         td.token = Tokens.IDENTIFIER;
         break;
-      case COLON:
-        //                observeColonEOL();
-        break;
       case RBRACE:
       case RPAREN:
       case RBRACKET:

--- a/src/test/java/ParserTest.java
+++ b/src/test/java/ParserTest.java
@@ -38,9 +38,9 @@ public class ParserTest extends TestUtils {
             pathToInput, expectedAST.toString(), AST.toString()));
   }
 
+  // Ignored case 2, 3, 6, 15, 16, 18 since they use removed multiline syntax
   @ParameterizedTest(name = "Run parser testcase no. {0}")
-  @ValueSource(
-      ints = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22})
+  @ValueSource(ints = {1, 4, 5, 7, 8, 9, 10, 11, 12, 13, 14, 17, 19, 20, 21, 22})
   public void testParser(int no) {
     compareAST("testcase" + no + ".txt", "ast" + no + ".json", "config" + no + ".json");
   }

--- a/src/test/java/com/virtuslab/using_directives/custom/CommentsTests.java
+++ b/src/test/java/com/virtuslab/using_directives/custom/CommentsTests.java
@@ -55,8 +55,8 @@ public class CommentsTests {
     testCode(UsingDirectiveKind.SpecialComment, 1, specialComment, plainComment);
     testCode(UsingDirectiveKind.SpecialComment, 2, specialComment, specialComment2);
     testCode(UsingDirectiveKind.SpecialComment, 1, multiLine1);
-    testCode(UsingDirectiveKind.SpecialComment, 3, multiLine2);
-    testCode(UsingDirectiveKind.SpecialComment, 4, multiLine1, multiLine2);
+    testCode(UsingDirectiveKind.SpecialComment, 1, multiLine2);
+    testCode(UsingDirectiveKind.SpecialComment, 2, multiLine1, multiLine2);
     testCode(UsingDirectiveKind.SpecialComment, 1, keywordDirective, specialComment, plainComment);
     testCode(UsingDirectiveKind.SpecialComment, 1, binaryScalaVersionNumericComment);
     testCode(


### PR DESCRIPTION
We can at some point return to multiline directives, but it's a bit dangerous currently and it's within the SIP proposal

More context here https://contributors.scala-lang.org/t/pre-sip-scala-cli-as-new-scala-command/5628/71