### PR TITLE
refactor: Don't allow multiline comments to simplify

### DIFF
--- a/src/main/java/com/virtuslab/using_directives/custom/SimpleCommentExtractor.java
+++ b/src/main/java/com/virtuslab/using_directives/custom/SimpleCommentExtractor.java
@@ -18,7 +18,6 @@ public class SimpleCommentExtractor {
   char c;
   int i;
   boolean insideSingleLineComment = false;
-  boolean insideMultiLineComment = false;
   boolean insideDirective = false;
 
   public boolean isEndOfLine() {
@@ -53,15 +52,7 @@ public class SimpleCommentExtractor {
     res = new char[source.length];
     for (i = 0; i < res.length; i++) {
       c = source[i];
-      if (insideMultiLineComment) {
-        if (c == '*' && next() == '/') {
-          skip();
-          skipNext();
-          insideMultiLineComment = false;
-          insideDirective = false;
-        } else if (insideDirective) use();
-        else skip();
-      } else if (insideSingleLineComment) {
+      if (insideSingleLineComment) {
         if (isEndOfLine()) {
           insideDirective = false;
           insideSingleLineComment = false;
@@ -72,10 +63,9 @@ public class SimpleCommentExtractor {
       else {
         if (c == '/') {
           if (next() == '/') insideSingleLineComment = true;
-          if (next() == '*') insideMultiLineComment = true;
 
           skip();
-          if (insideSingleLineComment || insideMultiLineComment) {
+          if (insideSingleLineComment) {
             skipNext();
             boolean hasIndicator = next() == USING_DIRECTIVE_INDICATOR;
             insideDirective = hasIndicator == useIndicator;

--- a/src/test/java/CommentExtractorTest.java
+++ b/src/test/java/CommentExtractorTest.java
@@ -20,7 +20,7 @@ public class CommentExtractorTest extends TestUtils {
   }
 
   @ParameterizedTest(name = "Run comment extractor testcase no. {0}")
-  @ValueSource(ints = {1, 2, 3, 4, 5, 6, 7, 8})
+  @ValueSource(ints = {1, 2, 3, 4, 5, 6, 7})
   public void testCommentExtractor(int no) {
     compare("comment" + no + ".txt", "output" + no + ".txt");
   }

--- a/src/test/resources/comment_extractor_tests/inputs/comment8.txt
+++ b/src/test/resources/comment_extractor_tests/inputs/comment8.txt
@@ -1,9 +1,0 @@
-/*> using option "-Xfatal-warnings"
-    option "-Xprint:typer"
-*/
-
-object Foo extends App {
-    try {
-        2 + 2
-    }
-}


### PR DESCRIPTION
No we decided no having a very simple syntax with only single line using directives. Since we no longer support multiline directives having using directives in multiline comments no longer make sense.