### PR TITLE
Remove redundant warning at the beginning of a value followed with a comma

### DIFF
--- a/src/main/java/com/virtuslab/using_directives/custom/Scanner.java
+++ b/src/main/java/com/virtuslab/using_directives/custom/Scanner.java
@@ -349,8 +349,6 @@ public class Scanner {
       reader.nextChar();
       getIdentRest();
     } else {
-      if (reader.ch == ',' && Character.isWhitespace(reader.lookaheadChar()))
-        warn("Use of commas as separators is deprecated. Only whitespace is neccessary.");
       finishNamed(Tokens.IDENTIFIER, td);
     }
   }

--- a/src/test/java/com/virtuslab/using_directives/parser/ParserUnitTest.java
+++ b/src/test/java/com/virtuslab/using_directives/parser/ParserUnitTest.java
@@ -146,7 +146,7 @@ public class ParserUnitTest {
     assertDiagnostic(
         reporter,
         0,
-        11,
+        13,
         "Use of commas as separators is deprecated. Only whitespace is neccessary.");
   }
 


### PR DESCRIPTION
Given:
```scala
//> using options -Werror, -Wconf:cat=deprecation:e, -Wconf:cat=unused:e
println("Deprecation warnings should have been printed")
```
Before: 
```text
[warn] ./example.sc:1:19
[warn] Use of commas as separators is deprecated. Only whitespace is neccessary.
[warn] //> using options -Werror, -Wconf:cat=deprecation:e, -Wconf:cat=unused:e
[warn]                   ^
[warn] ./example.sc:1:26
[warn] Use of commas as separators is deprecated. Only whitespace is neccessary.
[warn] //> using options -Werror, -Wconf:cat=deprecation:e, -Wconf:cat=unused:e
[warn]                          ^
[warn] ./example.sc:1:28
[warn] Use of commas as separators is deprecated. Only whitespace is neccessary.
[warn] //> using options -Werror, -Wconf:cat=deprecation:e, -Wconf:cat=unused:e
[warn]                            ^
[warn] ./example.sc:1:52
[warn] Use of commas as separators is deprecated. Only whitespace is neccessary.
[warn] //> using options -Werror, -Wconf:cat=deprecation:e, -Wconf:cat=unused:e
[warn] 
```
After:
```text
[warn] ./example.sc:1:26
[warn] Use of commas as separators is deprecated. Only whitespace is neccessary.
[warn] //> using options -Werror, -Wconf:cat=deprecation:e, -Wconf:cat=unused:e
[warn]                          ^
[warn] ./example.sc:1:52
[warn] Use of commas as separators is deprecated. Only whitespace is neccessary.
[warn] //> using options -Werror, -Wconf:cat=deprecation:e, -Wconf:cat=unused:e
[warn]                                                    ^
```