### PR TITLE
Pin Linux jobs to `ubuntu-22.04`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        OS: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        OS: ["ubuntu-22.04", "macos-latest", "windows-latest"]
     steps:
       - name: Set Git to preserve original line endings
         run: |
@@ -38,7 +38,7 @@ jobs:
       - name:  Show version
         run: ./gradlew :printVersion
       - name: Publish snapshot
-        if: ${{ github.event_name == 'push' && matrix.OS == 'ubuntu-latest' }}
+        if: ${{ github.event_name == 'push' && matrix.OS == 'ubuntu-22.04' }}
         run: ./gradlew publishReleasePublicationToSonatypeRepository --max-workers 1 closeAndReleaseSonatypeStagingRepository
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   publish:
     name: Release build and publish
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code
         uses: actions/checkout@v2

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   update_release_draft:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: release-drafter/release-drafter@v5
         env:


### PR DESCRIPTION
`ubuntu-latest` now switches to `ubuntu-24.04`, which may be the cause behind test reports failing...