### PR TITLE
Switch test reports to OSS flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,13 +28,12 @@ jobs:
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
       - name: Build with Gradle
         run: ./gradlew build
-      - name: Test Report
-        uses: dorny/test-reporter@v1
+      - name: Upload test report
+        uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
-          name: JUnit Tests ( ${{ matrix.OS }} )
+          name: test-results-${{ matrix.OS }}
           path: "**/test-results/**/*.xml"
-          reporter: java-junit
       - name:  Show version
         run: ./gradlew :printVersion
       - name: Publish snapshot

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,0 +1,22 @@
+name: 'Test Report'
+on:
+  workflow_run:
+    workflows: ['CI']
+    types:
+      - completed
+permissions:
+  statuses: write
+  checks: write
+  contents: write
+  pull-requests: write
+  actions: write
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dorny/test-reporter@v1
+        with:
+          artifact: /test-results-(.*)/
+          name: 'JUnit Tests ($1)'
+          path: '*.xml'
+          reporter: java-junit


### PR DESCRIPTION
https://github.com/dorny/test-reporter?tab=readme-ov-file#recommended-setup-for-public-repositories
We can only test the new flow once the changes are in main, unfortunately.