### PR TITLE
Remove `/* (...) */` comments support

### DIFF
--- a/src/main/java/com/virtuslab/using_directives/custom/Scanner.java
+++ b/src/main/java/com/virtuslab/using_directives/custom/Scanner.java
@@ -188,7 +188,7 @@ public class Scanner {
       reader.nextChar();
       getOperatorRest();
     } else if (ch == '/') {
-      if (skipComment()) return true;
+      if (skipLine()) return true;
       else {
         putChar('/');
         getOperatorRest();
@@ -272,7 +272,7 @@ public class Scanner {
   }
 
   // Unsupported: Keeping comments
-  private boolean skipComment() {
+  private boolean skipLine() {
     Runnable skipLine =
         () -> {
           reader.nextChar();
@@ -280,37 +280,9 @@ public class Scanner {
             reader.nextChar();
           }
         };
-    Runnable skipComment =
-        () -> {
-          int nested = 0;
-          boolean flag = true;
-          while (flag) {
-            if (reader.ch == '/') {
-              reader.nextChar();
-              if (reader.ch == '*') {
-                nested += 1;
-                reader.nextChar();
-              }
-            } else if (reader.ch == '*') {
-              reader.nextChar();
-              if (reader.ch == '/') {
-                if (nested > 0) {
-                  nested -= 1;
-                } else flag = false;
-                reader.nextChar();
-              }
-            } else {
-              reader.nextChar();
-            }
-          }
-        };
     reader.nextChar();
     if (reader.ch == '/') {
       skipLine.run();
-      return true;
-    } else if (reader.ch == '*') {
-      reader.nextChar();
-      skipComment.run();
       return true;
     } else {
       return false;
@@ -378,7 +350,7 @@ public class Scanner {
         break;
       case '/':
         char nxch = reader.lookaheadChar();
-        if (nxch == '/' || nxch == '*') finishNamed(Tokens.IDENTIFIER, td);
+        if (nxch == '/') finishNamed(Tokens.IDENTIFIER, td);
         else {
           putChar(reader.ch);
           reader.nextChar();

--- a/src/test/java/com/virtuslab/using_directives/parser/ParserUnitTest.java
+++ b/src/test/java/com/virtuslab/using_directives/parser/ParserUnitTest.java
@@ -187,4 +187,23 @@ public class ParserUnitTest {
     assertValueListSize(parsedDirective, "keyA", 1);
     assertValueListAtPath(parsedDirective, "keyA", List.of("0,2,3"));
   }
+
+  @Test
+  public void testAsterisksAndSlashes() {
+    String input = "//> using exclude */*/Foo.scala";
+    UsingDirectives parsedDirective = testCode(1, input);
+    assertValueListSize(parsedDirective, "exclude", 1);
+    assertValueListAtPath(parsedDirective, "exclude", List.of("*/*/Foo.scala"));
+  }
+
+  @Test
+  public void oldCommentsArentSkipped() {
+    String input = "//> using /* comment1 */ notTheKeyActually /* comment2 */ 42";
+    UsingDirectives parsedDirective = testCode(1, input);
+    assertValueListSize(parsedDirective, "/*", 7);
+    assertValueListAtPath(
+        parsedDirective,
+        "/*",
+        List.of("comment1", "*/", "notTheKeyActually", "/*", "comment2", "*/", "42"));
+  }
 }


### PR DESCRIPTION
Relevant to:
- https://github.com/VirtusLab/scala-cli/issues/3374

where the comment skipping logic was crashing on a value with asterisks and slashes: 

```scala
//> using exclude */*/Foo.scala
```